### PR TITLE
ft(enpoint): admin can edit a specific parties name

### DIFF
--- a/src/controllers/partyController.js
+++ b/src/controllers/partyController.js
@@ -40,6 +40,25 @@ class PartyController {
       }
     });
   }
+
+  static editAParty(req,res){
+    const id = parseInt(req.params.id);
+    const {name} = req.body
+    party.find((item)=>{
+      if (item.id === id ) {
+        item.name = name
+        return res.status(200).send({
+          success: true,
+          message: party
+        })
+      } else{
+        return res.status(404).send({
+          success: false,
+          message:"party dont exist"
+        })
+      }
+    })
+  }
 }
 
 export default PartyController

--- a/src/middlewares/partyMiddleware.js
+++ b/src/middlewares/partyMiddleware.js
@@ -30,6 +30,19 @@ class partyValidator {
       }
     });
     }
+
+    static editAParty(req,res,next) {
+        try {
+            const {name} = req.body;
+            if (!name) throw 'Can only edit party name'
+        } catch (error) {
+            return res.status(405).send({
+                success: false,
+                message: error
+            })
+        }
+        next()
+    }
 }
 
     export default partyValidator

--- a/src/routes/partyRouter.js
+++ b/src/routes/partyRouter.js
@@ -8,7 +8,8 @@ const versionedEndPoint = '/api/v1/parties';
 
 router.post(versionedEndPoint,partyValidator.createParty ,partyController.createParty);
 router.get(versionedEndPoint, partyController.getAllParties);
-router.get(`${versionedEndPoint}/:id`, partyController.getASpecificParty)
+router.get(`${versionedEndPoint}/:id`, partyController.getASpecificParty);
+router.patch(`${versionedEndPoint}/:id`,partyValidator.editAParty, partyController.editAParty);
 
 
 export default router;


### PR DESCRIPTION
[Delivers #163593718]
#### What does this PR do?
PATCH endpoint

#### Description of Task to be completed?
Have this endpoint working so as to edit a specific political parties name
/PATCH '/api/v1/parties/:id'
#### How should this be manually tested?
clone this reprository run npm open this url '/api/v1/parties/:id' on postman and edit the party name
if id is wrong it returns a 404 status, if you try to edit other details returns a 405
 
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#163593718
#### Screenshots (if appropriate)
#### Questions: