### PR TITLE
ft(endpoint): users can get all registered offices

### DIFF
--- a/src/controllers/officeController.js
+++ b/src/controllers/officeController.js
@@ -14,6 +14,13 @@ class officeController {
         office
       });
     }
+
+    static getAllOffice(req, res) {
+      return res.status(200).send({
+        success: true,
+        office
+      })
+    }
 }
 
 export default officeController;

--- a/src/middlewares/officeMiddleware.js
+++ b/src/middlewares/officeMiddleware.js
@@ -15,6 +15,16 @@ class officeValidator {
             }
         next()
     }
+
+    static getAllOffice(req,res,next) {
+        if (office.length === 0) {
+            return res.status(200).send({
+                success: true,
+                message: 'There are no registerd political parties'
+            })
+        }
+        next()
+    }
 }
 
 export default officeValidator;

--- a/src/routes/officeRouter.js
+++ b/src/routes/officeRouter.js
@@ -7,5 +7,6 @@ const router = express.Router();
 const versionedEndPoint = '/api/v1/office';
 
 router.post(versionedEndPoint,officeValidator.createOffice ,officeController.createOffice);
+router.get(versionedEndPoint, officeValidator.getAllOffice, officeController.getAllOffice);
 
 export default router


### PR DESCRIPTION
returns a message when there is no registered party
[Delivers #163635079]

#### What does this PR do?
GET endpoint

#### Description of Task to be completed?
Have this endpoint working so as to edit all registerd political offices
/PATCH '/api/v1/office'
#### How should this be manually tested?
clone this repository run npm open this url '/api/v1/office' on postman GET request and all registered offices should appear
 
#### Any background context you want to provide?
if there is no registered office the user gets a message no offices 
#### What are the relevant pivotal tracker stories?
#163635079
#### Screenshots (if appropriate)
#### Questions: