### PR TITLE
ft(endpoint): get-a-specific office endoint

### DIFF
--- a/src/controllers/officeController.js
+++ b/src/controllers/officeController.js
@@ -21,6 +21,24 @@ class officeController {
         office
       })
     }
+
+    static getASpecificOffice(req,res) {
+      const id = req.params.id
+      const Id= parseInt(id)
+      office.map((item)=>{
+        if(item.id === Id ) {
+          return res.status(200).send({
+            success: true,
+            message: item
+          })
+        } else{
+          return res.status(404).send({
+            success: false,
+            message: 'Political office dont exist'
+          });
+        }
+      });
+    }
 }
 
 export default officeController;

--- a/src/controllers/partyController.js
+++ b/src/controllers/partyController.js
@@ -66,7 +66,7 @@ class PartyController {
       party.find((item)=>{
         if (item.id === id) {
           party.splice(id-1, 1)
-          return res.status(501).send({
+          return res.status(204).send({
             success:true,
             message:'Party succesfully deleted',
             party

--- a/src/middlewares/officeMiddleware.js
+++ b/src/middlewares/officeMiddleware.js
@@ -25,6 +25,19 @@ class officeValidator {
         }
         next()
     }
+
+    static editAOffice(req,res,next) {
+        try {
+            const {name} = req.body;
+            if (!name) throw 'Can only edit office name'
+        } catch (error) {
+            return res.status(405).send({
+                success: false,
+                message: error
+            })
+        }
+        next()
+    }
 }
 
 export default officeValidator;

--- a/src/routes/officeRouter.js
+++ b/src/routes/officeRouter.js
@@ -8,5 +8,6 @@ const versionedEndPoint = '/api/v1/office';
 
 router.post(versionedEndPoint,officeValidator.createOffice ,officeController.createOffice);
 router.get(versionedEndPoint, officeValidator.getAllOffice, officeController.getAllOffice);
+router.get(`${versionedEndPoint}/:id`, officeController.getASpecificOffice);
 
 export default router

--- a/test/office.test.js
+++ b/test/office.test.js
@@ -1,0 +1,60 @@
+import supertest from 'supertest';
+import expect from 'expect';
+import app from '../src/app';
+import office from '../src/db/officeDb';
+
+const request = supertest;
+
+describe('/CREATE POLITICAL OFFICE', () => {
+  it('should create a political party', (done) => {
+    const body = {
+      "id": 3, "name": 'President', "type": 'Federal'
+    };
+    request(app)
+      .post('/api/v1/office')
+      .send(body)
+      .expect(201)
+      .expect((result) => {
+        console.log((result.body) )
+        expect(result.body.office[2]).toEqual(body);
+      })
+      .end(done);
+  });
+
+  it('should not create a political party', (done) => {
+    const party = {};
+    request(app)
+      .post('/api/v1/office')
+      .send(party)
+      .expect(400)
+      .end(done);
+  });
+});
+
+describe('/GET ALL OFFICE', ()=>{
+  it('should return all political office', (done)=>{
+    request(app)
+      .get('/api/v1/office')
+      .expect(200)
+      .expect((result) => {
+          console.log(result.body)
+        expect(result.body.office).toEqual(office)
+      })
+      .end(done)
+  })
+});
+
+describe('/GET A SPECIFIC OFFICE ', ()=>{
+    it('should return a specific political party', (done)=>{
+      let id= office.find((item)=> item.id)
+      console.log(id)
+      request(app)
+        .get(`/api/v1/office/1.toHexString()`)
+        .expect(200)
+        .expect((result) => {
+          expect(result.body.message).toEqual(office[0])
+        })
+        .end(done)
+    })
+  })
+

--- a/test/party.test.js
+++ b/test/party.test.js
@@ -45,4 +45,50 @@ describe('/GET ALL PARTIES', ()=>{
   })
 });
 
+describe('/GET A SPECIFIC PARTY ', ()=>{
+  it('should return a specific political party', (done)=>{
+    let id= party.find((item)=> item.id)
+    console.log(id)
+    request(app)
+      .get(`/api/v1/parties/1.toHexString()`)
+      .expect(200)
+      .expect((result) => {
+        expect(result.body.message).toEqual(party[0])
+      })
+      .end(done)
+  })
+})
+
+
+describe('/EDIT A SPECIFIC PARTY', ()=>{
+it ('should Edit a party name', (done)=>{
+  const name = 'her'
+  request(app)
+    .patch(`/api/v1/parties/1.toHexString()`)
+    .send({name:'her'})
+    .expect(200)
+    .expect((result)=>{
+      expect(result.body.message[0].name).toBe(name)
+    })
+    .end(done)
+});
+
+it ('should not Edit other field', (done)=>{
+  request(app)
+    .patch(`/api/v1/parties/1.toHexString()`)
+    .send({logourl:'url'})
+    .expect(405)
+    .end(done)
+})
+})
+
+describe('/DELETE A SPECIFIC PARTY', ()=>{
+it('should Delete a Party', (done)=>{
+  request(app)
+    .delete(`/api/v1/parties/1.toHexString()`)
+    .expect(204)
+    .end(done)
+})
+})
+
 


### PR DESCRIPTION
users should get the registered office requested for
[Delivers #163644760]

#### What does this PR do?
GET endpoint

#### Description of Task to be completed?
Have this endpoint working so as to get a specific office
/GET '/api/v1/office/:id'
#### How should this be manually tested?
clone this reprository run npm open this url '/api/v1/office/id' on postman GET request and get the office 
 
#### Any background context you want to provide?
if there are no registered office returns a status of 404 
#### What are the relevant pivotal tracker stories?
#163644760
#### Screenshots (if appropriate)
#### Questions: